### PR TITLE
NPM module missing index.js thus cannot use out of the box

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/leFunc.js");


### PR DESCRIPTION
Steps:
1. Run: npm install leFunc
2. Create file test.js with content: var leFunc = require("leFunc");
3. Run: node test.js

Error: Cannot find module 'leFunc'

There is no index.js file and so you can't actually require the module.

Adding the following index.js in the main leFunc directory fixes the problem:
module.exports = require("./lib/leFunc.js");
